### PR TITLE
Make declaration minification safe

### DIFF
--- a/angular-moment.js
+++ b/angular-moment.js
@@ -24,7 +24,7 @@ angular.module('angularMoment', [])
 
 					activeTimeout = $timeout(function () {
 						updateTime(momentInstance);
-					}, secondsUntilUpdate * 1000);
+					}, secondsUntilUpdate * 1000, false);
 				}
 
 				scope.$watch(attr.amTimeAgo, function (value) {


### PR DESCRIPTION
How about making the declaration minification safe and not relying on ngmin during build?
