### PR TITLE
Support moment's .calendar() with amCalendar filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ Add the module `angularMoment` as a dependency to your app module:
 var myapp = angular.module('myapp', ['angularMoment']);
 ```
 
-You can now start using the am-time-ago directive to format your
-relative timestamps. For example:
+### Timeago directive
+Use am-time-ago directive to format your relative timestamps. For example:
 
 ```html
 <span am-time-ago="message.time"></span>
@@ -43,9 +43,7 @@ The user will initially see "a few seconds ago", and about a minute
 after the span will automatically update with the text "a minute ago",
 etc.
 
-amDateFormat filter
-----
-
+### amDateFormat filter
 Format dates using moment.js format() method. Example:
 
 ```html
@@ -56,6 +54,19 @@ This snippet will format the given time as "Monday, October 7th 2013, 12:36:29 a
 
 For more information about Moment.JS formatting options, see the
 [docs for the format() function](http://momentjs.com/docs/#/displaying/format/).
+
+### amCalendar filter
+
+Format dates using moment.js calendar() method. Example:
+
+```html
+<span>{{message.time | amCalendar}}</span>
+```
+
+This snippet will format the given time as e.g. "Today 2:30 AM" or "Last Monday 2:30 AM" etc..
+
+For more information about Moment.JS calendar time format, see the
+[docs for the calendar() function](http://momentjs.com/docs/#/displaying/calendar-time/).
 
 License
 ----

--- a/angular-moment.js
+++ b/angular-moment.js
@@ -71,6 +71,23 @@ angular.module('angularMoment', [])
 			});
 		};
 	}])
+	.filter('amCalendar', ['$window', function ($window) {
+		'use strict';
+
+		return function (value) {
+			if (typeof value === 'undefined' || value === null) {
+				return '';
+			}
+
+			if (!isNaN(parseFloat(value)) && isFinite(value)) {
+				// Milliseconds since the epoch
+				value = new Date(parseInt(value, 10));
+			}
+			// else assume the given value is already a date
+
+			return $window.moment(value).calendar();
+		};
+	}])
 	.filter('amDateFormat', ['$window', function ($window) {
 		'use strict';
 
@@ -87,14 +104,15 @@ angular.module('angularMoment', [])
 
 			return $window.moment(value).format(format);
 		};
-	}]).filter('amDurationFormat', ['$window', function ($window) {
+	}])
+	.filter('amDurationFormat', ['$window', function ($window) {
 		'use strict';
 
 		return function (value, format, suffix) {
 			if (typeof value === 'undefined' || value === null) {
 				return '';
 			}
-			
+
 			// else assume the given value is already a duration in a format (miliseconds, etc)
 			return $window.moment.duration(value, format).humanize(suffix);
 		};

--- a/tests.js
+++ b/tests.js
@@ -170,6 +170,40 @@ describe('module angularMoment', function () {
 		});
 	});
 
+	describe('amCalendar filter', function () {
+		it('should convert today date to calendar form', function () {
+			var today = new Date();
+			$rootScope.testDate = new Date(today.getFullYear(), today.getMonth(), today.getDate(), 13, 33, 33);
+			var element = angular.element('<span>{{testDate|amCalendar}}</span>');
+			element = $compile(element)($rootScope);
+			$rootScope.$digest();
+			expect(element.text()).toBe('Today at 1:33 PM');
+		});
+
+		it('should convert date in long past to calendar form', function () {
+			$rootScope.testDate = new Date(2012, 2, 25, 13, 14, 15);
+			var element = angular.element('<span>{{testDate|amCalendar}}</span>');
+			element = $compile(element)($rootScope);
+			$rootScope.$digest();
+			expect(element.text()).toBe('03/25/2012');
+		});
+
+		it('should gracefully handle undefined values', function () {
+			var element = angular.element('<span>{{undefinedDate|amCalendar}}</span>');
+			element = $compile(element)($rootScope);
+			$rootScope.$digest();
+			expect(element.text()).toBe('');
+		});
+
+		it('should accept a numeric unix timestamp (milliseconds since the epoch) as input', function () {
+			$rootScope.testTimestamp = new Date(2012, 0, 22, 12, 46, 54).getTime();
+			var element = angular.element('<span>{{testTimestamp|amCalendar}}</span>');
+			element = $compile(element)($rootScope);
+			$rootScope.$digest();
+			expect(element.text()).toBe('01/22/2012');
+		});
+	});
+
 	describe('amDateFormat filter', function () {
 		it('should support displaying format', function () {
 			var today = new Date();


### PR DESCRIPTION
This PR adds support of moment.js [`.calendar()`](http://momentjs.com/docs/#/displaying/calendar-time/) format function.

Tests and updated docs in README.md is included.
