### PR TITLE
Add optional attribute `am-without-suffix` for #22

### DIFF
--- a/angular-moment.js
+++ b/angular-moment.js
@@ -1,7 +1,7 @@
 /* angular-moment.js / v0.5.2 / (c) 2013 Uri Shaked / MIT Licence */
 
 angular.module('angularMoment', [])
-	.constant('amTimeAgoConfig', { withoutSuffix: false })
+	.value('amTimeAgoConfig', { withoutSuffix: false})
 	.directive('amTimeAgo', ['$window', 'amTimeAgoConfig', function ($window, amTimeAgoConfig) {
 		'use strict';
 
@@ -9,6 +9,10 @@ angular.module('angularMoment', [])
 			var activeTimeout = null;
 			var currentValue;
 			var currentFormat;
+			var withoutSuffix = amTimeAgoConfig.withoutSuffix;
+			if (typeof attr.amWithoutSuffix !== 'undefined') {
+				withoutSuffix = attr.amWithoutSuffix;
+			}
 
 			function cancelTimer() {
 				if (activeTimeout) {
@@ -18,7 +22,7 @@ angular.module('angularMoment', [])
 			}
 
 			function updateTime(momentInstance) {
-				element.text(momentInstance.fromNow(amTimeAgoConfig.withoutSuffix));
+				element.text(momentInstance.fromNow(withoutSuffix));
 				var howOld = $window.moment().diff(momentInstance, 'minute');
 				var secondsUntilUpdate = 3600;
 				if (howOld < 1) {
@@ -58,6 +62,16 @@ angular.module('angularMoment', [])
 				currentValue = value;
 				updateMoment();
 			});
+			
+			if (typeof attr.amWithoutSuffix !== 'undefined') {
+				scope.$watch(attr.amWithoutSuffix, function (value) {
+					if ((typeof value === 'undefined') || (value === null) || (typeof value !== 'boolean')) {
+						return;
+					}
+				  withoutSuffix = value;
+				  updateMoment();
+				});
+			}
 
 			attr.$observe('amFormat', function (format) {
 				currentFormat = format;

--- a/tests.js
+++ b/tests.js
@@ -146,6 +146,32 @@ describe('module angularMoment', function () {
 			// Restore config
 			amTimeAgoConfig.withoutSuffix = false;
 		});
+		
+		it('should generate a time string without suffix (in directive) when configured to do so', function () {
+			$rootScope.testDate = new Date();
+			var element = angular.element('<span am-time-ago="testDate" am-without-suffix="true"></span>');
+			element = $compile(element)($rootScope);
+			$rootScope.$digest();
+			expect(element.text()).toBe('a few seconds');
+		});
+		
+		it('should generate a time string without suffix (in directive) when configured to do so2', function () {
+			$rootScope.testDate = new Date();
+			$rootScope.withSuffix = false;
+			var element = angular.element('<span am-time-ago="testDate" am-without-suffix="!withSuffix"></span>');
+			element = $compile(element)($rootScope);
+			$rootScope.$digest();
+			expect(element.text()).toBe('a few seconds');
+		});
+		
+		it('should generate a time string without suffix (in directive) when configured to do so2', function () {
+			$rootScope.testDate = new Date();
+			$rootScope.withSuffix = true;
+			var element = angular.element('<span am-time-ago="testDate" am-without-suffix="!withSuffix"></span>');
+			element = $compile(element)($rootScope);
+			$rootScope.$digest();
+			expect(element.text()).toBe('a few seconds ago');
+		});
 
 		describe('am-format attribute', function () {
 			it('should support custom date format', function () {
@@ -280,7 +306,7 @@ describe('module angularMoment', function () {
 	});
 
 
-	describe('amTimeAgoConfig constant', function () {
+	describe('amTimeAgoConfig value', function () {
 		it('should generate time with suffix by default', function () {
 			expect(amTimeAgoConfig.withoutSuffix).toBe(false);
 		});


### PR DESCRIPTION
basic usage:

``` html
<span am-time-ago="testDate" am-without-suffix="true"></span>
```
