### PR TITLE
Abandon the use of $window

### DIFF
--- a/angular-moment.js
+++ b/angular-moment.js
@@ -28,8 +28,9 @@
 		.constant('angularMomentConfig', {
 			timezone: '' // e.g. 'Europe/London'
 		})
+		.constant('moment', window.moment)
 		.constant('amTimeAgoConfig', { withoutSuffix: false})
-		.directive('amTimeAgo', ['$window', 'amTimeAgoConfig', function ($window, amTimeAgoConfig) {
+		.directive('amTimeAgo', ['$timeout', 'moment', 'amTimeAgoConfig', function ($timeout, moment, amTimeAgoConfig) {
 
 			return function (scope, element, attr) {
 				var activeTimeout = null;
@@ -39,14 +40,14 @@
 
 				function cancelTimer() {
 					if (activeTimeout) {
-						$window.clearTimeout(activeTimeout);
+						$timeout.cancel(activeTimeout);
 						activeTimeout = null;
 					}
 				}
 
 				function updateTime(momentInstance) {
 					element.text(momentInstance.fromNow(withoutSuffix));
-					var howOld = $window.moment().diff(momentInstance, 'minute');
+					var howOld = moment().diff(momentInstance, 'minute');
 					var secondsUntilUpdate = 3600;
 					if (howOld < 1) {
 						secondsUntilUpdate = 1;
@@ -56,14 +57,14 @@
 						secondsUntilUpdate = 300;
 					}
 
-					activeTimeout = $window.setTimeout(function () {
+					activeTimeout = $timeout(function () {
 						updateTime(momentInstance);
 					}, secondsUntilUpdate * 1000);
 				}
 
 				function updateMoment() {
 					cancelTimer();
-					updateTime($window.moment(currentValue, currentFormat));
+					updateTime(moment(currentValue, currentFormat));
 				}
 
 				scope.$watch(attr.amTimeAgo, function (value) {
@@ -113,10 +114,10 @@
 				});
 			};
 		}])
-		.factory('amMoment', ['$window', '$rootScope', function ($window, $rootScope) {
+		.factory('amMoment', ['moment', '$rootScope', function (moment, $rootScope) {
 			return {
 				changeLanguage: function (lang) {
-					var result = $window.moment.lang(lang);
+					var result = moment.lang(lang);
 					if (angular.isDefined(lang)) {
 						$rootScope.$broadcast('amMoment:languageChange');
 					}
@@ -124,7 +125,7 @@
 				}
 			};
 		}])
-		.filter('amCalendar', ['$window', '$log', 'angularMomentConfig', function ($window, $log, angularMomentConfig) {
+		.filter('amCalendar', ['moment', '$log', 'angularMomentConfig', function (moment, $log, angularMomentConfig) {
 
 			return function (value) {
 				if (typeof value === 'undefined' || value === null) {
@@ -136,15 +137,15 @@
 					value = new Date(parseInt(value, 10));
 				}
 
-				var moment = $window.moment(value);
-				if (!moment.isValid()) {
+				var date = moment(value);
+				if (!date.isValid()) {
 					return '';
 				}
 
-				return applyTimezone(moment, angularMomentConfig.timezone, $log).calendar();
+				return applyTimezone(date, angularMomentConfig.timezone, $log).calendar();
 			};
 		}])
-		.filter('amDateFormat', ['$window', '$log', 'angularMomentConfig', function ($window, $log, angularMomentConfig) {
+		.filter('amDateFormat', ['moment', '$log', 'angularMomentConfig', function (moment, $log, angularMomentConfig) {
 
 			return function (value, format) {
 				if (typeof value === 'undefined' || value === null) {
@@ -156,15 +157,15 @@
 					value = new Date(parseInt(value, 10));
 				}
 
-				var moment = $window.moment(value);
-				if (!moment.isValid()) {
+				var date = moment(value);
+				if (!date.isValid()) {
 					return '';
 				}
 
-				return applyTimezone(moment, angularMomentConfig.timezone, $log).format(format);
+				return applyTimezone(date, angularMomentConfig.timezone, $log).format(format);
 			};
 		}])
-		.filter('amDurationFormat', ['$window', function ($window) {
+		.filter('amDurationFormat', ['moment', function (moment) {
 
 			return function (value, format, suffix) {
 				if (typeof value === 'undefined' || value === null) {
@@ -172,7 +173,7 @@
 				}
 
 				// else assume the given value is already a duration in a format (miliseconds, etc)
-				return $window.moment.duration(value, format).humanize(suffix);
+				return moment.duration(value, format).humanize(suffix);
 			};
 		}]);
 

--- a/tests.js
+++ b/tests.js
@@ -2,12 +2,12 @@
  * Copyright (C) 2013, 2014, Uri Shaked.
  */
 
-/* global describe, inject, module, beforeEach, afterEach, it, expect, spyOn, moment */
+/* global describe, inject, module, beforeEach, afterEach, it, expect */
 
 'use strict';
 
 describe('module angularMoment', function () {
-	var $rootScope, $compile, $window, $filter, amTimeAgoConfig, originalTimeAgoConfig, angularMomentConfig,
+	var $rootScope, $compile, $filter, $timeout, moment, amTimeAgoConfig, originalTimeAgoConfig, angularMomentConfig,
 		originalAngularMomentConfig, amMoment;
 
 	beforeEach(module('angularMoment'));
@@ -15,8 +15,9 @@ describe('module angularMoment', function () {
 	beforeEach(inject(function ($injector) {
 		$rootScope = $injector.get('$rootScope');
 		$compile = $injector.get('$compile');
-		$window = $injector.get('$window');
 		$filter = $injector.get('$filter');
+		$timeout = $injector.get('$timeout');
+		moment = $injector.get('moment');
 		amMoment = $injector.get('amMoment');
 		amTimeAgoConfig = $injector.get('amTimeAgoConfig');
 		angularMomentConfig = $injector.get('angularMomentConfig');
@@ -24,7 +25,13 @@ describe('module angularMoment', function () {
 		originalAngularMomentConfig = angular.copy(angularMomentConfig);
 
 		// Ensure the language of moment.js is set to english by default
-		$window.moment.lang('en');
+		moment.lang('en');
+		// Add a sample timezone for tests
+		moment.tz.add({
+			zones: {
+				'Pacific/Tahiti': ['-9:58:16 - LMT 1912_9 -9:58:16', '-10 - TAHT']
+			}
+		});
 	}));
 
 	afterEach(function () {
@@ -33,12 +40,6 @@ describe('module angularMoment', function () {
 		angular.copy(originalAngularMomentConfig, angularMomentConfig);
 	});
 
-	// Add a sample timezone for tests
-	moment.tz.add({
-		zones: {
-			'Pacific/Tahiti': ['-9:58:16 - LMT 1912_9 -9:58:16', '-10 - TAHT']
-		}
-	});
 
 	describe('am-time-ago directive', function () {
 		it('should change the text of the element to "a few seconds ago" when given current time', function () {
@@ -98,7 +99,7 @@ describe('module angularMoment', function () {
 			$rootScope.testDate = new Date(new Date().getTime() - 44000);
 			var element = angular.element('<div am-time-ago="testDate"></div>');
 			element = $compile(element)($rootScope);
-			$rootScope.$digest();
+			$timeout.flush();
 			expect(element.text()).toBe('a few seconds ago');
 
 			var waitsInterval = setInterval(function () {
@@ -108,7 +109,7 @@ describe('module angularMoment', function () {
 				}
 
 				clearInterval(waitsInterval);
-				$rootScope.$digest();
+				$timeout.flush();
 				expect(element.text()).toBe('a minute ago');
 				done();
 			}, 50);
@@ -128,12 +129,11 @@ describe('module angularMoment', function () {
 			$rootScope.testDate = new Date().getTime();
 			var element = angular.element('<div am-time-ago="testDate"></div>');
 			element = $compile(element)($rootScope);
-			$rootScope.$digest();
+			$timeout.flush();
 			expect(element.text()).toBe('a few seconds ago');
 			$rootScope.testDate = '';
-			spyOn($window, 'clearTimeout').and.callThrough();
 			$rootScope.$digest();
-			expect($window.clearTimeout).toHaveBeenCalled();
+			$timeout.verifyNoPendingTasks();
 			expect(element.text()).toBe('');
 		});
 
@@ -141,7 +141,7 @@ describe('module angularMoment', function () {
 			$rootScope.testDate = null;
 			var element = angular.element('<div am-time-ago="testDate">Initial text</div>');
 			element = $compile(element)($rootScope);
-			$rootScope.$digest();
+			$timeout.flush();
 			expect(element.text()).toBe('Initial text');
 			$rootScope.testDate = new Date().getTime();
 			$rootScope.$digest();
@@ -153,10 +153,9 @@ describe('module angularMoment', function () {
 			$rootScope.testDate = new Date();
 			var element = angular.element('<span am-time-ago="testDate"></span>');
 			element = $compile(element)(scope);
-			$rootScope.$digest();
-			spyOn($window, 'clearTimeout').and.callThrough();
+			$timeout.flush();
 			scope.$destroy();
-			expect($window.clearTimeout).toHaveBeenCalled();
+			$timeout.verifyNoPendingTasks();
 		});
 
 		it('should generate a time string without suffix when configured to do so', function () {


### PR DESCRIPTION
It would be better to make moment() function injectable one time instead of finding it in $window every time.
Moreover, I've used $timeout instead of raw $window methods.
