### PR TITLE
Simplifying contribution guide

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,5 @@
 language: node_js
 node_js:
   - "0.10"
-before_script:
-  - npm install -g bower@1.3.x grunt-cli
-  - bower install
 after_success:
   - cat ./coverage/*/lcov.info | ./node_modules/coveralls/bin/coveralls.js

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,11 +14,6 @@ on you machine:
 - npm
 - Git
 
-If you install node through the binary installation file, **npm** will be already there.
-When **npm** is installed, use it to install the needed npm packages:
-
-`npm install -g grunt-cli bower`
-
 ## Installation
 
 To get the source of `angular-moment` clone the git repository via:
@@ -30,10 +25,6 @@ and install all needed dependencies via **npm**:
 
 `npm install`
 
-Then install all the needed client-side dependencies via **bower**:
-
-`bower install`
-
 `angular-moment` is now installed and ready to be built.
 
 ## Building
@@ -43,13 +34,13 @@ the development process. The following grunt tasks are provided:
 
 #### grunt test
 
-`grunt test` executes (as you might thought) the unit tests, which are located
+`npm test` executes (as you might thought) the unit tests, which are located
 in `tests.js`. The task uses the **karma** test runner to executes the tests with
 the **jasmine testing framework**. This task also checks the coding using **jshint**.
 
 #### grunt build
 
-`grunt build` updates the minified version of the code (angular-moment.min.js). It also
+`npm run build` updates the minified version of the code (angular-moment.min.js). It also
 checks the code using **jshint**.
 
 ## Contributing/Submitting changes
@@ -62,7 +53,7 @@ checks the code using **jshint**.
   - Use one branch per fix/feature
 - Make your changes
   - Make sure to provide a spec for unit tests (in `tests.js`)
-  - Run your tests with `grunt test`
+  - Run your tests with `npm test`
   - When all tests pass, everything's fine
 - Commit your changes
   - Please provide a git message which explains what you've done

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   },
   "scripts": {
     "postinstall": "bower install",
-    "test": "grunt test"
+    "test": "grunt test",
+    "build": "grunt build"
   }
 }

--- a/package.json
+++ b/package.json
@@ -10,22 +10,25 @@
     "moment": ">=2.8.0 <2.10.0"
   },
   "devDependencies": {
+    "bower": "^1.3.12",
+    "coveralls": "~2.11.0",
     "grunt": "~0.4.1",
-    "load-grunt-tasks": "0.6.0",
-    "grunt-contrib-uglify": "0.5.1",
+    "grunt-cli": "^0.1.13",
     "grunt-contrib-jshint": "~0.10.0",
+    "grunt-contrib-uglify": "0.5.1",
     "grunt-karma": "~0.8.2",
+    "grunt-ngdocs": "^0.2.1",
     "karma": "~0.12.0",
     "karma-coverage": "~0.2.0",
     "karma-jasmine": "~0.2.1",
     "karma-phantomjs-launcher": "~0.1.1",
-    "coveralls": "~2.11.0",
-    "grunt-ngdocs": "^0.2.1"
+    "load-grunt-tasks": "0.6.0"
   },
   "engines": {
     "node": ">=0.10.0"
   },
   "scripts": {
+    "postinstall": "bower install",
     "test": "grunt test"
   }
 }


### PR DESCRIPTION
If you add a `postinstall` script in the `package.json` it will run after `npm install`. You can add `bower install` in there. One step less to do when forking the repo and trying to run the tests.  Also there is no need to install `grunt-cli` and `bower` as global. They work fine as local packages. You can access the binaries via node_modules/.bin. BTW: There are a couple warnings on the tests I noticed:

WARN: 'Deprecation warning: moment construction falls back to js Date. This is discouraged and will be removed in upcoming major release. Please refer to https://github.com/moment/moment/issues/1407 for more info.'

........
WARN: 'Deprecation warning: moment().zone is deprecated, use moment().utcOffset instead. https://github.com/moment/moment/issues/1779'