### PR TITLE
add amNow directive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## 0.9.1 - TBD
+- Add `am-now` directive to show current time ([#119](https://github.com/urish/angular-moment/pull/119), contributed by [bbodenmiller](https://github.com/bbodenmiller)
 - Add support for locale strings customization ([#102](https://github.com/urish/angular-moment/pull/102), contributed by [vosi](https://github.com/vosi))
 - Support for changing the timezone via `amMoment.changeTimezone()` ([#92](https://github.com/urish/angular-moment/issues/92))
 - Support for AngularJS 1.4.x

--- a/README.md
+++ b/README.md
@@ -80,6 +80,16 @@ The user will initially see "a few seconds ago", and about a minute
 after the span will automatically update with the text "a minute ago",
 etc.
 
+### Now directive
+Use `am-now` directive to show the current time. For example:
+
+```html
+<time am-now></time>
+<time am-now="HH:ss"></time>
+```
+
+angular-moment will dynamically update the time stamp every 1 second. Any [moment.js supported format](http://momentjs.com/docs/#/displaying/format/) can be used to format the time stamp.
+
 ### amDateFormat filter
 Format dates using moment.js format() method. Example:
 


### PR DESCRIPTION
amNow directive to show & update current time. Fixes #103 & #117.

@urish if you could run with this initial cut and combine logic where it makes sense as well as work on tests that'd be great. Also now I'm seeing that time-ago supports am-format so it may make sense to add that to this directive.

### Now directive
Use `am-now` directive to show the current time. For example:

```html
<time am-now></time>
<time am-now="HH:ss"></time>
```

angular-moment will dynamically update the time stamp every 1 second. Any [moment.js supported format](http://momentjs.com/docs/#/displaying/format/) can be used to format the time stamp.