### PR TITLE
Added amDifference filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ myapp.run(function(amMoment) {
 
 ### Configuration
 
-Parameter `preprocess`(e.g: `unix`, `utc`) would pre-execute before. 
+Parameter `preprocess`(e.g: `unix`, `utc`) would pre-execute before.
 
 ```js
 angular.module('myapp').constant('angularMomentConfig', {
@@ -105,6 +105,20 @@ This snippet will format the given time as e.g. "Today 2:30 AM" or "Last Monday 
 For more information about Moment.JS calendar time format, see the
 [docs for the calendar() function](http://momentjs.com/docs/#/displaying/calendar-time/).
 
+### amDifference filter
+
+Get the difference between two dates in milliseconds.
+Parameters are date, units and usePrecision. Date defaults to current date. Example:
+
+```html
+<span>Scheduled {{message.createdAt | amDifference : null : 'days' }} days from now</span>
+```
+
+This snippet will return the number of days between the current date and the date filtered.
+
+For more information about Moment.JS difference function, see the
+[docs for the diff() function](http://momentjs.com/docs/#/displaying/difference/).
+
 ### Time zone support
 
 The `amDateFormat` and `amCalendar` filters can be configured to display dates aligned
@@ -144,5 +158,3 @@ IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
 CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
 TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-

--- a/angular-moment.js
+++ b/angular-moment.js
@@ -409,6 +409,42 @@
 
 		/**
 		 * @ngdoc filter
+		 * @name angularMoment.filter:amDifference
+		 * @module angularMoment
+		 */
+			.filter('amDifference', ['moment', 'amMoment', 'angularMomentConfig', function (moment, amMoment, angularMomentConfig) {
+				function amDifferenceFilter(value, otherValue, unit, usePrecision, preprocessValue, preprocessOtherValue) {
+					if (typeof value === 'undefined' || value === null) {
+						return '';
+					}
+
+					value = amMoment.preprocessDate(value, preprocessValue);
+					var date = moment(value);
+					if (!date.isValid()) {
+						return '';
+					}
+
+          var date2;
+					if (typeof otherValue === 'undefined' || otherValue === null) {
+						date2 = moment();
+					} else {
+					  value = amMoment.preprocessDate(otherValue, preprocessOtherValue);
+					  date2 = moment(otherValue);
+					  if (!date2.isValid()) {
+						  return '';
+					  }
+					}
+
+					return amMoment.applyTimezone(date).diff(amMoment.applyTimezone(date2), unit, usePrecision);
+				}
+
+				amDifferenceFilter.$stateful = angularMomentConfig.statefulFilters;
+
+				return amDifferenceFilter;
+			}])
+
+		/**
+		 * @ngdoc filter
 		 * @name angularMoment.filter:amDateFormat
 		 * @module angularMoment
 		 * @function
@@ -488,4 +524,3 @@
 		angularMoment(angular, window.moment);
 	}
 })();
-

--- a/tests.js
+++ b/tests.js
@@ -439,6 +439,65 @@ describe('module angularMoment', function () {
 		});
 	});
 
+	describe('amDifference filter', function () {
+		var amDifference;
+
+		beforeEach(function () {
+			amDifference = $filter('amDifference');
+		});
+
+		it('should take the difference of two dates in milliseconds', function () {
+			var today = new Date(2012, 0, 22, 0, 0, 0);
+			var testDate = new Date(today.getFullYear(), today.getMonth(), today.getDate(), 13, 33, 33);
+			expect(amDifference(testDate, today)).toBe(48813000);
+		});
+
+		it('should support passing "years", "months", "days", etc as a units parameter', function () {
+			var test = new Date(2012, 0, 22, 4, 46, 54);
+			var testDate1 = new Date(2013, 0, 22, 4, 46, 54);
+			expect(amDifference(testDate1, test, 'years')).toBe(1);
+			var testDate2 = new Date(2012, 1, 22, 4, 46, 54);
+			expect(amDifference(testDate2, test, 'months')).toBe(1);
+			var testDate3 = new Date(2012, 0, 23, 4, 46, 54);
+			expect(amDifference(testDate3, test, 'days')).toBe(1);
+		});
+
+    it('should allow rounding to be disabled via parameter', function () {
+			var test = new Date(2012, 0, 22, 4, 46, 54);
+			var testDate1 = new Date(test.getFullYear() + 1, test.getMonth() + 6, test.getDate());
+			expect(amDifference(testDate1, test, 'years')).toBe(1);
+			expect(amDifference(testDate1, test, 'years', true)).toBeCloseTo(1.5);
+    });
+
+		it('dates from the future should return negative values', function () {
+			var today = new Date(2012, 0, 22, 4, 46, 54);
+			var testDate = new Date(2013, 0, 22, 4, 46, 54);
+			expect(String(amDifference(today, testDate))).toContain('-');
+		});
+
+		it('should gracefully handle undefined values', function () {
+			expect(amDifference()).toBe('');
+		});
+
+		it('should accept a numeric unix timestamp (milliseconds since the epoch) as input', function () {
+			expect(amDifference(new Date(2012, 0, 22, 4, 46, 55).getTime(), new Date(2012, 0, 22, 4, 46, 54).getTime())).toBe(1000);
+		});
+
+		it('should apply the "utc" preprocessor when the string "utc" is given as a preprocessor argument', function () {
+			expect(amDifference(Date.UTC(2012, 0, 22, 0, 0, 1), Date(2012, 0, 22, 0, 0, 0), null, null, 'utc')).toBe(1000);
+			expect(amDifference(Date(2012, 0, 22, 0, 0, 1), Date.UTC(2012, 0, 22, 0, 0, 0), null, null, null, 'utc')).toBe(1000);
+		});
+
+		it('should apply the "unix" preprocessor if angularMomentConfig.preprocess is set to "unix" and no preprocessor is given', function () {
+			angularMomentConfig.preprocess = 'unix';
+			expect(amDifference(100001, 100000)).toBe(1000);
+		});
+
+		it('should return an empty string for invalid input', function () {
+			expect(amDifference('blah blah')).toBe('');
+		});
+	});
+
 	describe('amDateFormat filter', function () {
 		var amDateFormat;
 


### PR DESCRIPTION
Added support to use the amDifference filter to calculate the time difference between two moments/dates. I needed this in my project and thought I'd contribute. The amCalendar filter unit tests for preprocessors were failing on my machine so I am hoping there is some other reason why my unit tests for preprocessors were failing as well.