### PR TITLE
Duration format

### DIFF
--- a/angular-moment.js
+++ b/angular-moment.js
@@ -468,7 +468,7 @@
 		 * @module angularMoment
 		 */
 			.filter('amDifference', ['moment', 'amMoment', 'angularMomentConfig', function (moment, amMoment, angularMomentConfig) {
-				function amDifferenceFilter(value, otherValue, unit, usePrecision, format, preprocessValue, preprocessOtherValue) {
+				function amDifferenceFilter(value, otherValue, unit, usePrecision, preprocessValue, preprocessOtherValue, format) {
 					if (typeof value === 'undefined' || value === null) {
 						return '';
 					}

--- a/angular-moment.js
+++ b/angular-moment.js
@@ -468,7 +468,7 @@
 		 * @module angularMoment
 		 */
 			.filter('amDifference', ['moment', 'amMoment', 'angularMomentConfig', function (moment, amMoment, angularMomentConfig) {
-				function amDifferenceFilter(value, otherValue, unit, usePrecision, preprocessValue, preprocessOtherValue) {
+				function amDifferenceFilter(value, otherValue, unit, usePrecision, format, preprocessValue, preprocessOtherValue) {
 					if (typeof value === 'undefined' || value === null) {
 						return '';
 					}
@@ -490,8 +490,12 @@
 						}
 					}
 
-					return amMoment.applyTimezone(date).diff(amMoment.applyTimezone(date2), unit, usePrecision);
-				}
+          if (typeof format !== 'undefined' && format !== null && format !== false) {
+            var result = amMoment.applyTimezone(date).diff(amMoment.applyTimezone(date2));
+            return moment.duration(result).format(unit, usePrecision);
+          }
+          return amMoment.applyTimezone(date).diff(amMoment.applyTimezone(date2), unit, usePrecision);
+        }
 
 				amDifferenceFilter.$stateful = angularMomentConfig.statefulFilters;
 
@@ -582,7 +586,9 @@
 	if (typeof define === 'function' && define.amd) {
 		define(['angular', 'moment'], angularMoment);
 	} else if (typeof module !== 'undefined' && module && module.exports) {
-		angularMoment(angular, require('moment'));
+		var moment = require('moment');
+		require('moment-duration-format');
+		angularMoment(angular, moment);
 		module.exports = 'angularMoment';
 	} else {
 		angularMoment(angular, (typeof global !== 'undefined' ? global : window).moment);

--- a/bower.json
+++ b/bower.json
@@ -9,7 +9,8 @@
 	],
 	"dependencies": {
 		"angular": ">=1.2.0 <1.5.0",
-		"moment": ">=2.8.0 <2.11.0"
+		"moment": ">=2.8.0 <2.11.0",
+		"moment-duration-format": "~1.3.0"
 	},
 	"devDependencies": {
 		"angular-mocks": "1.4.x",

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -17,6 +17,7 @@ module.exports = function (config) {
 			'bower_components/moment/moment.js',
 			'bower_components/moment/{locale,lang}/fr.js',
 			'bower_components/moment-timezone/moment-timezone.js',
+			'bower_components/moment-duration-format/lib/moment-duration-format.js',
 			'angular-moment.js',
 
 			// angular-mocks defines a global variable named 'module' which confuses moment-timezone.js.

--- a/tests.js
+++ b/tests.js
@@ -516,6 +516,15 @@ describe('module angularMoment', function () {
 			expect(amDifference(testDate, today)).toBe(48813000);
 		});
 
+		it('should support use unit param as format when format param is true ', function () {
+			var test = new Date(2012, 0, 21, 1, 40, 50);
+			var testDate1 = new Date(2013, 0, 22, 2, 41, 51);
+			expect(amDifference(testDate1, test, 'D', false, true)).toBe('367');
+			expect(amDifference(testDate1, test, 'M', false, true)).toBe('12');
+			expect(amDifference(testDate1, test, 'Y', false, true)).toBe('1');
+			expect(amDifference(testDate1, test, 'Y M D h m s', false, true)).toBe('1 0 2 1 1 1');
+		});
+
 		it('should support passing "years", "months", "days", etc as a units parameter', function () {
 			var test = new Date(2012, 0, 22, 4, 46, 54);
 			var testDate1 = new Date(2013, 0, 22, 4, 46, 54);

--- a/tests.js
+++ b/tests.js
@@ -519,10 +519,10 @@ describe('module angularMoment', function () {
 		it('should support use unit param as format when format param is true ', function () {
 			var test = new Date(2012, 0, 21, 1, 40, 50);
 			var testDate1 = new Date(2013, 0, 22, 2, 41, 51);
-			expect(amDifference(testDate1, test, 'D', false, true)).toBe('367');
-			expect(amDifference(testDate1, test, 'M', false, true)).toBe('12');
-			expect(amDifference(testDate1, test, 'Y', false, true)).toBe('1');
-			expect(amDifference(testDate1, test, 'Y M D h m s', false, true)).toBe('1 0 2 1 1 1');
+			expect(amDifference(testDate1, test, 'D', false, null, null, true)).toBe('367');
+			expect(amDifference(testDate1, test, 'M', false, null, null, true)).toBe('12');
+			expect(amDifference(testDate1, test, 'Y', false, null, null, true)).toBe('1');
+			expect(amDifference(testDate1, test, 'Y M D h m s', false, null, null, true)).toBe('1 0 2 1 1 1');
 		});
 
 		it('should support passing "years", "months", "days", etc as a units parameter', function () {


### PR DESCRIPTION
Based on #124 

1. Add Moment duration format plugin https://github.com/jsmreese/moment-duration-format
2. Feature on amDifference: new param format (true or false). If true use unit params and precision to call moment-duration-format format function.
3. A few tests on new the feature

BTW To keep backward compatibility I have chosen to add a param, so if the format param is not present or false, keep the same function as it is now.

