### PR TITLE
Allow moment 2.11.x

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -9,7 +9,7 @@
 	],
 	"dependencies": {
 		"angular": ">=1.2.0 <1.6.0",
-		"moment": ">=2.8.0 <2.11.0"
+		"moment": ">=2.8.0 <2.12.0"
 	},
 	"devDependencies": {
 		"angular-mocks": "1.4.x",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "LICENSE"
   ],
   "dependencies": {
-    "moment": ">=2.8.0 <2.11.0"
+    "moment": ">=2.8.0 <2.12.0"
   },
   "devDependencies": {
     "bower": "1.6.3",
@@ -27,7 +27,7 @@
     "grunt-karma": "0.12.1",
     "grunt-ngdocs": "0.2.9",
     "jasmine-core": "2.3.4",
-    "karma": "0.13.14",
+    "karma": "0.13.19",
     "karma-coverage": "0.5.3",
     "karma-jasmine": "0.3.6",
     "karma-phantomjs-launcher": "0.2.1",


### PR DESCRIPTION
- Allow moment 2.11.x as a dependencie
- Bump karma to fix builds errors (https://github.com/karma-runner/karma/issues/1782)
