### PR TITLE
amLocal has no effect if a utc preprocessor is configured

### DIFF
--- a/angular-moment.js
+++ b/angular-moment.js
@@ -471,7 +471,7 @@
 		 */
 			.filter('amLocal', ['moment', 'amMoment', 'angularMomentConfig', function (moment, amMoment, angularMomentConfig) {
 				var amLocalFn = function(value) {
-					return moment.isMoment(value) ? value.local() : null
+					return moment.isMoment(value) ? value.local() : null;
 				};
 
 				// Append amLocal to preprocessor so that it isn't overridden by a existing utc preprocessing

--- a/angular-moment.js
+++ b/angular-moment.js
@@ -469,9 +469,32 @@
 		 * @name angularMoment.filter:amLocal
 		 * @module angularMoment
 		 */
-			.filter('amLocal', ['moment', function (moment) {
-				return function (value) {
-					return moment.isMoment(value) ? value.local() : null;
+			.filter('amLocal', ['moment', 'amMoment', 'angularMomentConfig', function (moment, amMoment, angularMomentConfig) {
+				var amLocalFn = function(value) {
+					return moment.isMoment(value) ? value.local() : null
+				};
+
+				// Append amLocal to preprocessor so that it isn't overridden by a existing utc preprocessing
+				var _preprocess = angularMomentConfig.preprocess;
+				angularMomentConfig.preprocess = function(value) {
+					return amLocalFn(_preprocess(value));
+				};
+
+				return amLocalFn;
+			}])
+
+		/**
+		 * @ngdoc filter
+		 * @name angularMoment.filter:amLocalFormat
+		 * @module angularMoment
+		 */
+			.filter('amLocalFormat', ['moment', function (moment) {
+				return function (value, format) {
+					if (!moment.isMoment(value)) {
+						return null;
+					}
+
+					return moment(value.local()).format(format);
 				};
 			}])
 


### PR DESCRIPTION
I've got an app that uses both am-time-ago, and amDateFormat, and works with dates that are normalized to UTC.

am-time-ago needs preprocessing to make the UTC to local timezone conversion.  

In order to show local times for moments formatted with amDateFormat, I use `{{dateStamp | amUtc | amLocal | amDateFormat: 'dddd, MMMM Do YYYY, h:mm:ss a'}}`.

### The issue this pull request addresses
Assume dateStamp is 'Feb 22, 2016, 10:31:00 UTC', and local timezone is EST 
The above call would be expected to produce 'Monday, February 22nd 2016, 5:31:00 am', but it instead returns the original UTC time.

1. amUtc creates the moment object setting the _isUTC flag to true.
2. amLocal sets the _isUTC flag to false
3. amDateFormat calls preprocessDate() which rests the _isUTC flag back to true because of the configuration for am-time-ago
4. amDateFormat outputs the formatted UTC time no matter which timezone amLocal resolves

### Two proposed resolutions
1. Append the amLocal functionality to any existing preprocessing when the amLocal filter is called.
2. Added a amLocalFormat function which calls `moment.format()` directly and avoids any preprocessing.

I believe that resolution #1 is the best since users would expect preprocessing to apply to all of the filters.  If the PR is going to be accepted, then I will remove the unused resolution, add unit tests, and any applicable documentation, and do everything else to get to spec with the contributing guide.