### PR TITLE
Adds an additional typeof check for the global.moment instance

### DIFF
--- a/angular-moment.js
+++ b/angular-moment.js
@@ -732,6 +732,6 @@
 	} else if (typeof module !== 'undefined' && module && module.exports && (typeof require === 'function') && !isElectron) {
 		module.exports = angularMoment(require('angular'), require('moment'));
 	} else {
-		angularMoment(angular, (typeof global !== 'undefined' ? global : window).moment);
+		angularMoment(angular, (typeof global !== 'undefined' && typeof global.moment !== 'undefined' ? global : window).moment);
 	}
 })();


### PR DESCRIPTION
It is possible for the global object to exist but global.moment to not exist which results in `Error: Moment cannot by found by angular-moment!`

This happens in edge cases such as when using QtWebKit where a global object is defined but global.moment is undefined. Because of this, when calling the global instance of moment, we need to add an additional `global.moment` check to ensure it actually exists.

